### PR TITLE
Fix lm grid calculation

### DIFF
--- a/docs/changes/32.bugfix.rst
+++ b/docs/changes/32.bugfix.rst
@@ -1,0 +1,2 @@
+- fix a numerical issue in the lm grid calculation, caused by adding a big number to small values in the lm grid
+- use torch.float64 for rd grid and lm grid calculation

--- a/docs/changes/32.maintenance.rst
+++ b/docs/changes/32.maintenance.rst
@@ -1,0 +1,1 @@
+- use c from scipy in scan.py

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -383,7 +383,6 @@ class Observation:
         3d array
             Returns a 3d array with every pixel containing a l and m value
         """
-        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         lm_grid = torch.zeros(self.rd.shape, device=self.device)

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -225,8 +225,6 @@ class Observation:
                 len(self.array.st_num) * (len(self.array.st_num) - 1) / 2
             )
             self.baselines.times_unique = torch.unique(self.baselines.time)
-            self.ra = torch.tensor([0]).to(self.device)
-            self.dec = torch.tensor([0]).to(self.device)
 
         self.rd = self.create_rd_grid()
         self.lm = self.create_lm_grid()
@@ -366,7 +364,7 @@ class Observation:
 
         r = (
             torch.arange(self.img_size, device=self.device, dtype=torch.float64) - self.img_size / 2
-        ) * res + ra
+        ) * res
         d = (
             torch.arange(self.img_size, device=self.device, dtype=torch.float64) - self.img_size / 2
         ) * res + dec
@@ -396,13 +394,13 @@ class Observation:
 
         lm_grid = torch.zeros(self.rd.shape, device=self.device, dtype=torch.float64)
         lm_grid[:, :, 0] = (
-            torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0] - ra)
+            torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0])
         ).T
         lm_grid[:, :, 1] = (
             torch.sin(self.rd[..., 1]) * torch.cos(dec)
             - torch.cos(self.rd[..., 1])
             * torch.sin(dec)
-            * torch.cos(self.rd[..., 0] - ra)
+            * torch.cos(self.rd[..., 0])
         ).T
         return lm_grid
 

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -359,14 +359,15 @@ class Observation:
         # define resolution
         res = fov / self.img_size
 
-        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         r = (
-            torch.arange(self.img_size, device=self.device, dtype=torch.float64) - self.img_size / 2
+            torch.arange(self.img_size, device=self.device, dtype=torch.float64)
+            - self.img_size / 2
         ) * res
         d = (
-            torch.arange(self.img_size, device=self.device, dtype=torch.float64) - self.img_size / 2
+            torch.arange(self.img_size, device=self.device, dtype=torch.float64)
+            - self.img_size / 2
         ) * res + dec
 
         _, R = torch.meshgrid((r, r), indexing="ij")
@@ -389,18 +390,13 @@ class Observation:
         3d array
             Returns a 3d array with every pixel containing a l and m value
         """
-        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         lm_grid = torch.zeros(self.rd.shape, device=self.device, dtype=torch.float64)
-        lm_grid[:, :, 0] = (
-            torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0])
-        ).T
+        lm_grid[:, :, 0] = (torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0])).T
         lm_grid[:, :, 1] = (
             torch.sin(self.rd[..., 1]) * torch.cos(dec)
-            - torch.cos(self.rd[..., 1])
-            * torch.sin(dec)
-            * torch.cos(self.rd[..., 0])
+            - torch.cos(self.rd[..., 1]) * torch.sin(dec) * torch.cos(self.rd[..., 0])
         ).T
         return lm_grid
 

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -361,7 +361,7 @@ class Observation:
         ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
-        r = (torch.arange(self.img_size) - self.img_size / 2) * res + ra
+        r = (torch.arange(self.img_size) - self.img_size / 2) * res
         d = (torch.arange(self.img_size) - self.img_size / 2) * res + dec
         _, R = torch.meshgrid((r, r), indexing="ij")
         D, _ = torch.meshgrid((d, d), indexing="ij")
@@ -387,14 +387,10 @@ class Observation:
         dec = torch.deg2rad(self.dec)
 
         lm_grid = torch.zeros(self.rd.shape, device=self.device)
-        lm_grid[:, :, 0] = (
-            torch.cos(self.rd[:, :, 1]) * torch.sin(self.rd[:, :, 0] - ra)
-        ).T
+        lm_grid[:, :, 0] = (torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0])).T
         lm_grid[:, :, 1] = (
-            torch.sin(self.rd[:, :, 1]) * torch.cos(dec)
-            - torch.cos(self.rd[:, :, 1])
-            * torch.sin(dec)
-            * torch.cos(self.rd[:, :, 0] - ra)
+            torch.sin(self.rd[..., 1]) * torch.cos(dec)
+            - torch.cos(self.rd[..., 1]) * torch.sin(dec) * torch.cos(self.rd[..., 0])
         ).T
         return lm_grid
 

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -224,6 +224,8 @@ class Observation:
                 len(self.array.st_num) * (len(self.array.st_num) - 1) / 2
             )
             self.baselines.times_unique = torch.unique(self.baselines.time)
+            self.ra = torch.tensor([0]).to(self.device)
+            self.dec = torch.tensor([0]).to(self.device)
 
         self.rd = self.create_rd_grid()
         self.lm = self.create_lm_grid()
@@ -362,12 +364,12 @@ class Observation:
         dec = torch.deg2rad(self.dec)
 
         r = (
-            torch.arange(self.img_size, dtype=torch.float64) - self.img_size / 2
+            torch.arange(self.img_size, device=self.device, dtype=torch.float64) - self.img_size / 2
         ) * res + ra
         d = (
-            torch.arange(self.img_size, dtype=torch.float64) - self.img_size / 2
+            torch.arange(self.img_size, device=self.device, dtype=torch.float64) - self.img_size / 2
         ) * res + dec
-        print(d.dtype)
+
         _, R = torch.meshgrid((r, r), indexing="ij")
         D, _ = torch.meshgrid((d, d), indexing="ij")
         rd_grid = torch.cat([R[..., None], D[..., None]], dim=2)
@@ -391,7 +393,7 @@ class Observation:
         ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
-        lm_grid = torch.zeros(self.rd.shape, device=self.device)
+        lm_grid = torch.zeros(self.rd.shape, device=self.device, dtype=torch.float64)
         lm_grid[:, :, 0] = (
             torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0] - ra)
         ).T

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -359,12 +359,13 @@ class Observation:
         # define resolution
         res = fov / self.img_size
 
+        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         r = (
             torch.arange(self.img_size, device=self.device, dtype=torch.float64)
             - self.img_size / 2
-        ) * res
+        ) * res + ra
         d = (
             torch.arange(self.img_size, device=self.device, dtype=torch.float64)
             - self.img_size / 2
@@ -390,13 +391,18 @@ class Observation:
         3d array
             Returns a 3d array with every pixel containing a l and m value
         """
+        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         lm_grid = torch.zeros(self.rd.shape, device=self.device, dtype=torch.float64)
-        lm_grid[:, :, 0] = (torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0])).T
+        lm_grid[:, :, 0] = (
+            torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0] - ra)
+        ).T
         lm_grid[:, :, 1] = (
             torch.sin(self.rd[..., 1]) * torch.cos(dec)
-            - torch.cos(self.rd[..., 1]) * torch.sin(dec) * torch.cos(self.rd[..., 0])
+            - torch.cos(self.rd[..., 1])
+            * torch.sin(dec)
+            * torch.cos(self.rd[..., 0] - ra)
         ).T
         return lm_grid
 

--- a/pyvisgen/simulation/observation.py
+++ b/pyvisgen/simulation/observation.py
@@ -359,13 +359,12 @@ class Observation:
         # define resolution
         res = fov / self.img_size
 
-        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         r = (
             torch.arange(self.img_size, device=self.device, dtype=torch.float64)
             - self.img_size / 2
-        ) * res + ra
+        ) * res
         d = (
             torch.arange(self.img_size, device=self.device, dtype=torch.float64)
             - self.img_size / 2
@@ -391,18 +390,13 @@ class Observation:
         3d array
             Returns a 3d array with every pixel containing a l and m value
         """
-        ra = torch.deg2rad(self.ra)
         dec = torch.deg2rad(self.dec)
 
         lm_grid = torch.zeros(self.rd.shape, device=self.device, dtype=torch.float64)
-        lm_grid[:, :, 0] = (
-            torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0] - ra)
-        ).T
+        lm_grid[:, :, 0] = (torch.cos(self.rd[..., 1]) * torch.sin(self.rd[..., 0])).T
         lm_grid[:, :, 1] = (
             torch.sin(self.rd[..., 1]) * torch.cos(dec)
-            - torch.cos(self.rd[..., 1])
-            * torch.sin(dec)
-            * torch.cos(self.rd[..., 0] - ra)
+            - torch.cos(self.rd[..., 1]) * torch.sin(dec) * torch.cos(self.rd[..., 0])
         ).T
         return lm_grid
 

--- a/pyvisgen/simulation/scan.py
+++ b/pyvisgen/simulation/scan.py
@@ -1,7 +1,7 @@
 from math import pi
 
 import torch
-from astropy.constants import c
+from scipy.constants import c
 from torch.special import bessel_j1
 
 
@@ -71,18 +71,8 @@ def calc_fourier(img, bas, lm, spw_low, spw_high):
     wn = w_cmplt[..., None] * (n - 1)
     del l, m, n, u_cmplt, v_cmplt, w_cmplt
 
-    K1 = torch.exp(
-        -2
-        * pi
-        * 1j
-        * (ul + vm + wn) / 3e8 * spw_low
-    )[..., None, None]
-    K2 = torch.exp(
-        -2
-        * pi
-        * 1j
-        * (ul + vm + wn) / 3e8 * spw_high
-    )[..., None, None]
+    K1 = torch.exp(-2 * pi * 1j * (ul + vm + wn) / c * spw_low)[..., None, None]
+    K2 = torch.exp(-2 * pi * 1j * (ul + vm + wn) / c * spw_high)[..., None, None]
     del ul, vm, wn
     return img * K1, img * K2
 
@@ -93,8 +83,8 @@ def calc_beam(X1, X2, rd, ra, dec, ant_diam, spw_low, spw_high):
     theta = angularDistance(rd, ra, dec)
     tds = diameters * theta[..., None]
 
-    E1 = jinc(2 * pi / c.value * spw_low * tds)
-    E2 = jinc(2 * pi / c.value * spw_high * tds)
+    E1 = jinc(2 * pi / c * spw_low * tds)
+    E2 = jinc(2 * pi / c * spw_high * tds)
 
     assert E1.shape == E2.shape
 

--- a/pyvisgen/simulation/scan.py
+++ b/pyvisgen/simulation/scan.py
@@ -75,13 +75,13 @@ def calc_fourier(img, bas, lm, spw_low, spw_high):
         -2
         * pi
         * 1j
-        * (ul / c.value * spw_low + vm / c.value * spw_low + wn / c.value * spw_low)
+        * (ul + vm + wn) / 3e8 * spw_low
     )[..., None, None]
     K2 = torch.exp(
         -2
         * pi
         * 1j
-        * (ul / c.value * spw_high + vm / c.value * spw_high + wn / c.value * spw_high)
+        * (ul + vm + wn) / 3e8 * spw_high
     )[..., None, None]
     del ul, vm, wn
     return img * K1, img * K2
@@ -168,15 +168,20 @@ def integrate(X1, X2):
     """
     X_f = torch.stack((X1, X2))
     int_m = torch.sum(X_f, dim=2)
+
     del X_f
+
     # only integrate for 1 sky dimension
     # 2d sky is reshaped to 1d by sensitivity mask
     # int_l = torch.sum(int_m, dim=2)
     # del int_m
     int_f = 0.5 * torch.sum(int_m, dim=0)
     del int_m
+
     X_t = torch.stack(torch.split(int_f, int(int_f.shape[0] / 2), dim=0))
     del int_f
+
     int_t = 0.5 * torch.sum(X_t, dim=0)
     del X_t
+
     return int_t

--- a/pyvisgen/simulation/scan.py
+++ b/pyvisgen/simulation/scan.py
@@ -115,7 +115,7 @@ def angularDistance(rd, ra, dec):
         Returns angular Distance for every pixel in rd grid with respect
         to source position
     """
-    r = rd[..., 0] - torch.deg2rad(ra.to(rd.device))
+    r = rd[..., 0]
     d = rd[..., 1] - torch.deg2rad(dec.to(rd.device))
     theta = torch.arcsin(torch.sqrt(r**2 + d**2))
     return theta

--- a/pyvisgen/simulation/visibility.py
+++ b/pyvisgen/simulation/visibility.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass, fields
 
 import torch
+from tqdm import tqdm
 
 import pyvisgen.simulation.scan as scan
-
-from tqdm import tqdm
 
 
 @dataclass
@@ -39,7 +38,15 @@ class Visibilities:
         ]
 
 
-def vis_loop(obs, SI, num_threads=10, noisy=True, mode="full", batch_size=100, show_progress=False):
+def vis_loop(
+    obs,
+    SI,
+    num_threads=10,
+    noisy=True,
+    mode="full",
+    batch_size=100,
+    show_progress=False,
+):
     torch.set_num_threads(num_threads)
     torch._dynamo.config.suppress_errors = True
 
@@ -96,10 +103,10 @@ def vis_loop(obs, SI, num_threads=10, noisy=True, mode="full", batch_size=100, s
         raise ValueError("Unsupported mode!")
 
     batches = torch.arange(bas[:].shape[1]).split(batch_size)
-    
+
     if show_progress:
         batches = tqdm(batches)
-        
+
     for p in batches:
         bas_p = bas[:][:, p]
 


### PR DESCRIPTION
Fixes lm grid calculation in `pyvisgen.simulation.observation`. Subtracting source `ra` from the `ra` component of the `rd_grid` resulted in a wrong `l` component in the `lm_grid`.