### PR TITLE
Use obs.layout instead of passing the layout name

### DIFF
--- a/docs/changes/38.optimization.rst
+++ b/docs/changes/38.optimization.rst
@@ -1,0 +1,1 @@
+- Use `obs.layout` instead of passing the layout name separately in `pyvisgen.fits.writer.create_vis_hdu`

--- a/pyvisgen/fits/writer.py
+++ b/pyvisgen/fits/writer.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 import pyvisgen.layouts.layouts as layouts
 
 
-def create_vis_hdu(data, obs, layout="vlba", source_name="sim-source-0"):
+def create_vis_hdu(data, obs, source_name="sim-source-0"):
     u = data.u
 
     v = data.v
@@ -95,8 +95,8 @@ def create_vis_hdu(data, obs, layout="vlba", source_name="sim-source-0"):
     hdu_vis.header["EXTNAME"] = ("AIPS UV", "AIPS UV")
     hdu_vis.header["EXTVER"] = (1, "Version number of table")
     hdu_vis.header["OBJECT"] = (source_name, "Source name")
-    hdu_vis.header["TELESCOP"] = (layout, "Telescope name")
-    hdu_vis.header["INSTRUME"] = (layout, "Instrument name (receiver or ?)")
+    hdu_vis.header["TELESCOP"] = (obs.layout, "Telescope name")
+    hdu_vis.header["INSTRUME"] = (obs.layout, "Instrument name (receiver or ?)")
     hdu_vis.header["DATE-OBS"] = (date_obs, "Observation date")
     hdu_vis.header["DATE-MAP"] = (date_map, "File processing date")
     hdu_vis.header["BSCALE"] = (1, "Always 1")


### PR DESCRIPTION
The layout name is passed to the `pyvisgen.fits.writer.create_vis_hdu` method as an optional argument.
Since we also pass the `Observation` class object we can just directly get the layout name from the class attribute `obs.layout` instead of passing the string separately.