### PR TITLE
Fix image rotation

### DIFF
--- a/docs/changes/40.bugfix.rst
+++ b/docs/changes/40.bugfix.rst
@@ -1,0 +1,3 @@
+- Fix image rotation caused by bug in rd/lm grid computation in ``pyvisgen.simulation.observation.Obseravtion``
+- Fix field order in ``pyvisgen.simulation.observation.ValidBaselineSubset`` data class
+- Flip input image at the beginning of ``pyvisgen.simulation.visibility.vis_loop`` to ensure correct indexing, e.g. for plotting

--- a/pyvisgen/simulation/visibility.py
+++ b/pyvisgen/simulation/visibility.py
@@ -50,6 +50,8 @@ def vis_loop(
     torch.set_num_threads(num_threads)
     torch._dynamo.config.suppress_errors = True
 
+    SI = torch.flip(SI, dims=[1])
+
     # define unpolarized sky distribution
     SI = SI.permute(dims=(1, 2, 0))
     I = torch.zeros((SI.shape[0], SI.shape[1], 4), dtype=torch.cdouble)


### PR DESCRIPTION
- Fix image rotation caused by bug in rd/lm grid computation
- Fix field order in ``pyvisgen.simulation.observation.ValidBaselineSubset`` data class
- Flip input image at the beginning of `pyvisgen.simulation.visibility.vis_loop` to ensure correct indexing, e.g. for plotting