### PR TITLE
Make tests more verbose in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Tests
         run: |
-          pytest --cov --cov-report=xml
+          pytest -vv --cov --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/docs/changes/50.maintenance.rst
+++ b/docs/changes/50.maintenance.rst
@@ -1,0 +1,1 @@
+- Increase verbosity of tests in CI


### PR DESCRIPTION
Increase verbosity of pytest in CI. This will make it easier to see what function fails