### PR TITLE
Use np.complex128 instead of float64 as dtype, move delta into np.arange

### DIFF
--- a/pyvisgen/gridding/gridder.py
+++ b/pyvisgen/gridding/gridder.py
@@ -241,10 +241,6 @@ def grid_data(uv_data, freq_data, conf):
 
     # bins are shifted by delta/2 so that maximum in uv space matches maximum
     # in numpy fft
-    bins = (
-        np.arange(start=-(N / 2) * delta, stop=(N / 2 + 1) * delta, step=delta)
-        - delta / 2
-    )
     bins = np.arange(
         start=-(N / 2 + 1 / 2) * delta,
         stop=(N / 2 + 1 / 2) * delta,

--- a/pyvisgen/gridding/gridder.py
+++ b/pyvisgen/gridding/gridder.py
@@ -245,6 +245,12 @@ def grid_data(uv_data, freq_data, conf):
         np.arange(start=-(N / 2) * delta, stop=(N / 2 + 1) * delta, step=delta)
         - delta / 2
     )
+    bins = np.arange(
+        start=-(N / 2 + 1 / 2) * delta,
+        stop=(N / 2 + 1 / 2) * delta,
+        step=delta,
+        dtype=np.complex128,
+    )
     # if len(bins) - 1 > N:
     #   bins = np.delete(bins, -1)
 


### PR DESCRIPTION
Computing bins by moving `delta` into the `np.arange`  method and using `np.complex128` instead of `np.float64` may solve the precision issue, possibly due to different algorithms used in `np.complex128`.

```python
bins = np.arange(start=-(N / 2 + 1 / 2) *  delta, stop=(N/2 + 1 / 2) * delta, step=delta, dtype=np.complex128) 
```