### PR TITLE
Use dependency groups instead of optional deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           python --version
-          pip install -e .[tests]
+          pip install --group tests -e .
           pip freeze
           pip list
 
@@ -111,7 +111,7 @@ jobs:
         run: |
           sudo apt update --yes && sudo apt install --yes git 
           pip install -U pip towncrier
-          pip install -e .[docs]
+          pip install --group docs -e .
           git describe --tags
 
       - name: Build docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,14 +5,11 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.10"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+    python: "3.11"
+  jobs:
+    install:
+      - pip install --upgrade pip
+      - pip install --group docs .
 
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm[toml]>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "pyvisgen"
 dynamic = ["version"]
 description = "Simulate radio interferometer observations and visibility generation with the RIME formalism."
-readme = "README.md"
+readme = "README.rst"
 authors = [
   { name = "Kevin Schmitz, Felix Geyer, Stefan Fröse, Anno Knierim, Tom Groß" },
 ]
@@ -91,8 +91,11 @@ dev = [
 [project.scripts]
 pyvisgen-simulate = "pyvisgen.simulation.scripts.create_dataset:main"
 
-[tool.setuptools_scm]
-write_to = "pyvisgen/_version.py"
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "pyvisgen/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,8 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "pyvisgen/_version.py"
 
-[tool.setuptools.packages.find]
-where = ["."]
+[tool.hatch.build.targets.wheel]
+packages = ["."]
 
 [tool.coverage.run]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,7 @@ dependencies = [
   "astropy<=6.1.0",
   "click",
   "h5py",
-  "ipython",
   "joblib",
-  "jupyter",
-  "matplotlib",
   "natsort",
   "numpy",
   "pandas",
@@ -50,7 +47,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+plot = [
+  "matplotlib",
+]
 
+[dependency-groups]
 tests = [
   "coverage!=6.3.0",
   "h5py",
@@ -61,10 +62,6 @@ tests = [
   "tomli",
 ]
 
-dev = [
-  "pre-commit",
-]
-
 docs = [
   "graphviz",
   "ipython",
@@ -73,7 +70,6 @@ docs = [
   "notebook",
   "numpydoc",
   "pydata_sphinx_theme",
-  "pyvisgen[all]",
   "sphinx",
   "sphinx-changelog",
   "sphinx-copybutton",
@@ -82,6 +78,14 @@ docs = [
   "sphinx_automodapi",
   "sphinxcontrib-bibtex",
   "tomli; python_version < '3.11'",
+]
+
+dev = [
+  "ipython",
+  "jupyter",
+  "pre-commit",
+  {include-group = "tests"},
+  {include-group = "docs"},
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ docs = [
   "graphviz",
   "ipython",
   "jupyter",
+  "matplotlib",
   "nbsphinx",
   "notebook",
   "numpydoc",


### PR DESCRIPTION
Dependency groups are recommended over optional dependencies for, e.g., dev dependencies, because they are not included in the metadata when the package is built. See more here: https://packaging.python.org/en/latest/specifications/dependency-groups/

Also ditch setuptools in favor of [hatch](https://hatch.pypa.io/). See here, [why](https://hatch.pypa.io/1.9/why/) this may be recommended.