### PR TITLE
Bugfix: Pass RA/Dec as NumPy array to Astropy SkyCoord

### DIFF
--- a/docs/changes/110.bugfix.rst
+++ b/docs/changes/110.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which raised an AttributeError when using a :func:`~torch.tensor` in an :class:`~astropy.coordinates.SkyCoord` object

--- a/src/pyvisgen/simulation/observation.py
+++ b/src/pyvisgen/simulation/observation.py
@@ -856,7 +856,9 @@ class Observation:
         if time.shape == ():
             time = time[None]
 
-        src_crd = SkyCoord(ra=self.ra, dec=self.dec, unit=(un.deg, un.deg))
+        src_crd = SkyCoord(
+            ra=self.ra.numpy(), dec=self.dec.numpy(), unit=(un.deg, un.deg)
+        )
         # Calculate for all times
         # calculate GHA, Greenwich as reference
         GHA = time.sidereal_time("apparent", "greenwich") - src_crd.ra.to(un.hourangle)


### PR DESCRIPTION
Using a `torch.tensor` raises an Attribute error because `torch.dtype` objects have no attribute `kind` which is checked in `astropy.coordinates.angles.core`.

